### PR TITLE
Align to draft-ietf-openpgp-pqc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 This is the working area for the individual Internet-Draft, "PQ/T Composite Schemes for OpenPGP using NIST and Brainpool Domain Parameters".
 
-* [Editor's Copy](https://openpgp-pqc.github.io/draft-individual-openpgp-nist-bp-comp/#go.draft-individual-openpgp-nist-bp-comp.html)
-* [Datatracker Page](https://datatracker.ietf.org/doc/draft-individual-openpgp-nist-bp-comp)
-* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-individual-openpgp-nist-bp-comp)
-* [Compare Editor's Copy to Individual Draft](https://openpgp-pqc.github.io/draft-individual-openpgp-nist-bp-comp/#go.draft-individual-openpgp-nist-bp-comp.diff)
+* [Editor's Copy](https://openpgp-pqc.github.io/draft-ehlen-openpgp-nist-bp-comp/#go.draft-ehlen-openpgp-nist-bp-comp.html)
+* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ehlen-openpgp-nist-bp-comp)
+* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-ehlen-openpgp-nist-bp-comp)
+* [Compare Editor's Copy to Individual Draft](https://openpgp-pqc.github.io/draft-ehlen-openpgp-nist-bp-comp/#go.draft-ehlen-openpgp-nist-bp-comp.diff)
 
 
 ## Contributing
 
 See the
-[guidelines for contributions](https://github.com/openpgp-pqc/draft-individual-openpgp-nist-bp-comp/blob/gh-pages/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/openpgp-pqc/draft-ehlen-openpgp-nist-bp-comp/blob/gh-pages/CONTRIBUTING.md).
 
 Contributions can be made by creating pull requests.
 The GitHub interface supports creating pull requests using the Edit (✏) button.

--- a/draft-ehlen-openpgp-nist-bp-comp.md
+++ b/draft-ehlen-openpgp-nist-bp-comp.md
@@ -530,6 +530,7 @@ The following table describes the ECDSA parameters and artifact lengths:
 |                      | NIST-P-256                       | NIST P-384                                                 | brainpoolP256r1                       | brainpoolP384r1                       |
 ---------------------: | -------------------------------- | ---------------------------------------------------------- | ------------------------------------- | ------------------------------------- |
 Algorithm ID reference | TBD (ML-DSA-44+ECDSA-NIST-P-256) | TBD (ML-DSA-65+ECDSA-NIST-P-384,ML-DSA-87+ECDSA-NIST-P-384 | TBD (ML-DSA-65+ECDSA-brainpoolP256r1) | TBD (ML-DSA-87+ECDSA-brainpoolP384r1) |
+Field size             | 32 octets                        | 48 octets                                                  | 32 octets                             | 48 octets                             |
 Public key             | 65 octets                        | 97 octets                                                  | 65 octets                             | 97 octets                             |
 Secret key             | 32 octets                        | 48 octets                                                  | 32 octets                             | 48 octets                             |
 Signature value R      | 32 octets                        | 48 octets                                                  | 32 octets                             | 48 octets                             |

--- a/draft-ehlen-openpgp-nist-bp-comp.md
+++ b/draft-ehlen-openpgp-nist-bp-comp.md
@@ -50,176 +50,38 @@ author:
 
 normative:
 
+  RFC9580:
+
   RFC7748:
 
   RFC8032:
 
   RFC3394:
 
-  RFC8126:
-
-  draft-ietf-openpgp-pqc-12:
-    target: https://www.ietf.org/archive/id/draft-ietf-openpgp-pqc-12.html
-    title: Post-Quantum Cryptography in OpenPGP (draft-ietf-openpgp-pqc-12)
-    author:
-      -
-        ins: S. Kousidis
-        name: Stavros Kousidis
-      -
-        ins: J. Roth
-        name: Johannes Roth
-      -
-        ins: F. Strenzke
-        name: Falko Strenzke
-      -
-        ins: A. Wussler
-        name: Aron Wussler
-    date: 2025
-
-  draft-ietf-openpgp-pqc-12:
-    target: https://www.ietf.org/archive/id/draft-ietf-openpgp-pqc-12.html
-    title: Post-Quantum Cryptography in OpenPGP (draft-ietf-openpgp-pqc-12)
-    author:
-      -
-        ins: S. Kousidis
-        name: Stavros Kousidis
-      -
-        ins: J. Roth
-        name: Johannes Roth
-      -
-        ins: F. Strenzke
-        name: Falko Strenzke
-      -
-        ins: A. Wussler
-        name: Aron Wussler
-    date: 2025
-
-
-informative:
-
   RFC5639:
 
-  NIST-PQC:
-    target: https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization
-    title: Post-Quantum Cryptography Standardization
-    author:
-      -
-        ins: L. Chen
-        name: Lily Chen
-      -
-        ins: D. Moody
-        name: Dustin Moody
-      -
-        ins: Y. Liu
-        name: Yi-Kai Liu
-    date: December 2016
+  I-D.draft-ietf-openpgp-pqc:
 
-  NISTIR-8413:
-    target: https://doi.org/10.6028/NIST.IR.8413-upd1
-    title: Status Report on the Third Round of the NIST Post-Quantum Cryptography Standardization Process
+  SEC1:
+    target: https://secg.org/sec1-v2.pdf
+    title: "Standards for Efficient Cryptography 1 (SEC 1)"
     author:
-      -
-        ins: G. Alagic
-        name: Gorjan Alagic
-      -
-        ins: D. Apon
-        name: Daniel Apon
-      -
-        ins: D. Cooper
-        name: David Cooper
-      -
-        ins: Q. Dang
-        name: Quynh Dang
-      -
-        ins: T. Dang
-        name: Thinh Dang
-      -
-        ins: J. Kelsey
-        name: John Kelsay
-      -
-        ins: J. Lichtinger
-        name: Jacob Lichtinger
-      -
-        ins: C. Miller
-        name: Carl Miller
-      -
-        ins: D. Moody
-        name: Dustin Moody
-      -
-        ins: R. Peralta
-        name: Rene Peralta
-      -
-        ins: R. Perlner
-        name: Ray Perlner
-      -
-        ins: A. Robinson
-        name: Angela Robinson
-      -
-        ins: D. Smith-Tone
-        name: Daniel Smith-Tone
-      -
-        ins: Y. Liu
-        name: Yi-Kai Liu
-    date: September 2022
-    seriesinfo:
-      NIST IR 8413
+      - org: Standards for Efficient Cryptography Group
+    date: May 2009
 
-  SP800-56C:
-    target: https://doi.org/10.6028/NIST.SP.800-56Cr2
-    title: Recommendation for Key-Derivation Methods in Key-Establishment Schemes
-    author:
-      -
-        ins: E. Barker
-        name: Elaine Barker
-      -
-        ins: L. Chen
-        name: Lily Chen
-      -
-        ins: R. Davis
-        name: Richard Davis
-    date: August 2020
-    seriesinfo:
-      NIST Special Publication 800-56C Rev. 2
+  FIPS-203:
+      target: https://doi.org/10.6028/NIST.FIPS.203
+      title: Module-Lattice-Based Key-Encapsulation Mechanism Standard
+      author:
+        - org: National Institute of Standards and Technology
+      date: August 2024
 
-  SP800-185:
-    target: https://doi.org/10.6028/NIST.SP.800-185
-    title: 'SHA-3 Derived Functions: cSHAKE, KMAC, TupleHash, and ParallelHash'
-    author:
-      -
-        ins: J. Kelsey
-        name: John Kelsey
-      -
-        ins: S. Chang
-        name: Shu-jen Chang
-      -
-        ins: R. Perlner
-        name: Ray Perlner
-    date: December 2016
-    seriesinfo:
-      NIST Special Publication 800-185
-
-  SP800-56A:
-    target: https://doi.org/10.6028/NIST.SP.800-56Ar3
-    title: Recommendation for Pair-Wise Key-Establishment Schemes Using Discrete Logarithm Cryptography
-    author:
-      -
-        ins: E. Barker
-        name: Elaine Barker
-      -
-        ins: L. Chen
-        name: Lily Chen
-      -
-        ins: A. Roginsky
-        name: Allen Roginsky
-      -
-        ins: A. Vassilev
-        name: Apostol Vassilev
-      -
-        ins: R. Davis
-        name: Richard Davis
-    date: April 2018
-    seriesinfo:
-      NIST Special Publication 800-56A Rev. 3
+  FIPS-204:
+      target: https://doi.org/10.6028/NIST.FIPS.204
+      title: Module-Lattice-Based Digital Signature Standard
+      author:
+        - org: National Institute of Standards and Technology
+      date: August 2024
 
   SP800-186:
     target: https://doi.org/10.6028/NIST.SP.800-186
@@ -251,33 +113,7 @@ informative:
     seriesinfo:
       NIST Special Publication 800-186
 
-  SEC1:
-    target: https://secg.org/sec1-v2.pdf
-    title: "Standards for Efficient Cryptography 1 (SEC 1)"
-    author:
-      - org: Standards for Efficient Cryptography Group
-    date: May 2009
-
-  FIPS-203:
-      target: https://doi.org/10.6028/NIST.FIPS.203.ipd
-      title: Module-Lattice-Based Key-Encapsulation Mechanism Standard
-      author:
-        - org: National Institute of Standards and Technology
-      date: August 2023
-
-  FIPS-204:
-      target: https://doi.org/10.6028/NIST.FIPS.204.ipd
-      title: Module-Lattice-Based Digital Signature Standard
-      author:
-        - org: National Institute of Standards and Technology
-      date: August 2023
-
-  FIPS-205:
-      target: https://doi.org/10.6028/NIST.FIPS.205.ipd
-      title: Stateless Hash-Based Digital Signature Standard
-      author:
-        - org: National Institute of Standards and Technology
-      date: August 2023
+informative:
 
   TR-03111:
       target: https://www.bsi.bund.de/DE/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/Technische-Richtlinien/TR-nach-Thema-sortiert/tr03111/TR-03111_node.html
@@ -285,52 +121,6 @@ informative:
       author:
         - org: Federal Office for Information Security, Germany
       date: June 2018
-
-  GHP18:
-    target: https://doi.org/10.1007/978-3-319-76578-5_7
-    title: KEM Combiners
-    date: 2018
-    author:
-      -
-        ins: F. Giacon
-        name: Federico Giacon
-      -
-        ins: F. Heuer
-        name: Felix Heuer
-      -
-        ins: B. Poettering
-        name: Bertram Poettering
-
-  BDPA08:
-    target: https://doi.org/10.1007/978-3-540-78967-3_11
-    title: On the Indifferentiability of the Sponge Construction
-    author:
-      -
-        ins: G. Bertoni
-        name: Guido Bertoni
-      -
-        ins: J. Daemen
-        name: Joan Daemen
-      -
-        ins: M. Peters
-        name: Michael Peters
-      -
-        ins: G. Assche
-        name: Gilles van Assche
-    date: 2008
-
-  CS03:
-    target: https://doi.org/10.1137/S0097539702403773
-    title: Design and Analysis of Practical Public-Key Encryption Schemes Secure against Adaptive Chosen Ciphertext Attack
-    author:
-      -
-        ins: R. Cramer
-        name: Ronald Cramer
-      -
-        ins: V. Shoup
-        name: Victor Shoup
-    date: 2003
-
 
   ABH+21:
     target: https://doi.org/10.1007/978-3-030-77870-5_4
@@ -356,16 +146,15 @@ informative:
         name: Doreen Riepl
     date: 2021
 
-
 --- abstract
 
-This document defines PQ/T composite schemes based on ML-KEM and ML-DSA combined with ECC algorithms using the NIST and Brainpool domain parameters for the OpenPGP protocol.
+This document defines PQ/T composite schemes based on ML-KEM and ML-DSA combined with ECDH and ECDSA algorithms using the NIST and Brainpool domain parameters for the OpenPGP protocol.
 
 --- middle
 
 # Introduction
 
-This document defines PQ/T composite schemes based on ML-KEM and ML-DSA combined with ECDH and ECDSA using the NIST and Brainpool domain parameters for the OpenPGP protocol. It is an extension of [draft-ietf-openpgp-pqc-12], which introduces post-quantum cryptography in OpenPGP using hybrid KEMs and digital signatures combining ML-KEM and ML-DSA with ECC algorithms based on the Edwards Curves defined in {{RFC7748}} and {{RFC8032}}.
+This document defines PQ/T composite schemes based on ML-KEM and ML-DSA combined with ECDH and ECDSA using the NIST and Brainpool domain parameters for the OpenPGP protocol. It is an extension of {{I-D.draft-ietf-openpgp-pqc}}, which introduces post-quantum cryptography in OpenPGP using hybrid KEMs and digital signatures combining ML-KEM and ML-DSA with ECC algorithms based on the Edwards Curves defined in {{RFC7748}} and {{RFC8032}}.
 
 Due to their long-standing and wide deployment, there are well-tested, secure, and efficient implementations of ECDSA and ECDH with NIST-curves {{SP800-186}}. The same applies to Brainpool curves {{RFC5639}} which are recommended or required in certain regulatory domains, for instance in Germany {{TR-03111}}.  The purpose of this document is to support users who would like to or have to use such hybrid KEMs and/or signatures with OpenPGP.
 
@@ -388,26 +177,25 @@ All schemes listed here are believed to provide security in the presence of a cr
 
 ML-KEM [FIPS-203] is based on the hardness of solving the Learning with Errors problem in module lattices (MLWE).
 The scheme is believed to provide security against cryptanalytic attacks by classical as well as quantum computers.
-This specification defines ML-KEM only in composite combination with ECC-based encryption schemes in order to provide a pre-quantum security fallback.
+This specification defines ML-KEM only in composite combination with ECDH encryption schemes in order to provide a pre-quantum security fallback.
 
 ### ML-DSA {#mldsa-intro}
 
 ML-DSA [FIPS-204] is a signature scheme that, like ML-KEM, is based on the hardness of solving the Learning With Errors problem and a variant of the Short Integer Solution problem in module lattices (MLWE and SelfTargetMSIS).
-Accordingly, this specification only defines ML-DSA in composite combination with ECC-based signature schemes.
+Accordingly, this specification only defines ML-DSA in composite combinaton with ECDSA signature schemes.
 
 ## Elliptic Curve Cryptography
 
-The ECC-based encryption is defined here as a KEM.
-This is in contrast to {{?RFC9580}} where the ECC-based encryption is defined as a public-key encryption scheme.
+The ECDH encryption is defined here as a KEM.
 
-All elliptic curves for the use in the composite combinations are taken from {{?RFC9580}}.
+All elliptic curves for the use in the composite combinations are taken from {{RFC9580}}.
 
 For interoperability this extension offers ML-* in composite combinations with the NIST curves P-256, P-384 defined in {{SP800-186}} and the Brainpool curves brainpoolP256r1, brainpoolP384r1 defined in {{RFC5639}}.
 
 ## Applicable Specifications for the use of PQC Algorithms in OpenPGP
 
-This document is to be understood as an extension of [draft-ietf-openpgp-pqc-12], which introduced PQC in OpenPGP, in that it defines further algorithm code points.
-All general specifications in [draft-ietf-openpgp-pqc-12] that pertain to the ML-KEM and ML-DSA composite schemes or generally cryptographic schemes defined therein equally apply to the schemes specified in this document.
+This document is to be understood as an extension of {{I-D.draft-ietf-openpgp-pqc}}, which introduced PQC in OpenPGP, in that it defines further algorithm code points.
+All general specifications in {{I-D.draft-ietf-openpgp-pqc}} that pertain to the ML-KEM and ML-DSA composite schemes or generally cryptographic schemes defined therein equally apply to the schemes specified in this document.
 
 # Preliminaries
 
@@ -477,62 +265,58 @@ This draft will not be sent to IANA without every listed algorithm having a non-
 
 ## Composite KEMs
 
-The ML-KEM + ECDH public-key encryption involves both the ML-KEM and an ECC-based KEM in an a priori non-separable manner.
+The ML-KEM + ECDH public-key encryption involves both the ML-KEM and an ECDH KEM in an a priori non-separable manner.
 This is achieved via KEM combination, i.e. both key encapsulations/decapsulations are performed in parallel, and the resulting key shares are fed into a key combiner to produce a single shared secret for message encryption.
 
 ## Composite Signatures
 
-The ML-DSA + ECDSA signature consists of independent ML-DSA and ECC signatures, and an implementation MUST successfully validate both signatures to state that the ML-DSA + ECDSA signature is valid.
+The ML-DSA + ECDSA signature consists of independent ML-DSA and ECDSA signatures, and an implementation MUST successfully validate both signatures to state that the ML-DSA + ECDSA signature is valid.
 
 ## Key Version Binding
 
 All PQ(/T) asymmetric algorithms are to be used only in v6 (and newer) keys and certificates, with the single exception of ML-KEM-768+X25519 (algorithm ID 35), which is also allowed in v4 encryption-capable subkeys.
 
-# Composite KEM schemes
+# Composite KEM Schemes
 
 ## Building Blocks
 
-### ECC-Based KEMs {#ecc-kem}
+### ECDH KEM {#ecc-kem}
 
 In this section we define the encryption, decryption, and data formats for the ECDH component of the composite algorithms.
 
-{{tab-ecdh-nist-artifacts}} and {{tab-ecdh-brainpool-artifacts}} describe the ECDH-KEM parameters and artifact lengths.
+{{tab-ecdh-nist-artifacts}} and {{tab-ecdh-brainpool-artifacts}} describe the ECDH KEM parameters and artifact lengths.
 
 
 {: title="NIST curves parameters and artifact lengths" #tab-ecdh-nist-artifacts}
 |                          | NIST P-256                                               | NIST P-384                                                        |
 | ------------------------ | -------------------------------------------------------- | --------------------------------------------------------          |
 | Algorithm ID reference   | TBD (ML-KEM-512+ECDH-NIST-P-256)                         | TBD (ML-KEM-768+ECDH-NIST-P-384, ML-KEM-1024+ECDH-NIST-P-384, )   |
-| Field size               | 32 octets                                                | 48 octets                                                         |
+| ECDH KEM                 | ECDH-KEM {{ecdh-kem}}                                    | ECDH-KEM {{ecdh-kem}}                                             |
 | ECDH public key          | 65 octets of SEC1-encoded public point                   | 97 octets of SEC1-encoded public point                            |
 | ECDH secret key          | 32 octets big-endian encoded secret scalar               | 48 octets big-endian encoded secret scalar                        |
 | ECDH ephemeral           | 65 octets of SEC1-encoded ephemeral point                | 97 octets of SEC1-encoded ephemeral point                         |
-| ECDH share               | 65 octets of SEC1-encoded shared point                   | 97 octets of SEC1-encoded shared point                            |
-| Key share                | 32 octets                                                | 64 octets                                                         |
-| Hash                     | SHA3-256                                                 | SHA3-512                                                          |
+| ECDH key share           | 32 octets                                                | 48 octets                                                         |
 
 {: title="Brainpool curves parameters and artifact lengths" #tab-ecdh-brainpool-artifacts}
 |                          | brainpoolP256r1                                          | brainpoolP384r1                                          |
 | ------------------------ | -------------------------------------------------------- | -------------------------------------------------------- |
 | Algorithm ID reference   | TBD (ML-KEM-768+ECDH-brainpoolP256r1)                    | TBD (ML-KEM-1024+ECDH-brainpoolP384r1)                   |
-| Field size               | 32 octets                                                | 48 octets                                                |
+| ECDH KEM                 | ECDH-KEM {{ecdh-kem}}                                    | ECDH-KEM {{ecdh-kem}}                                    |
 | ECDH public key          | 65 octets of SEC1-encoded public point                   | 97 octets of SEC1-encoded public point                   |
 | ECDH secret key          | 32 octets big-endian encoded secret scalar               | 48 octets big-endian encoded secret scalar               |
 | ECDH ephemeral           | 65 octets of SEC1-encoded ephemeral point                | 97 octets of SEC1-encoded ephemeral point                |
-| ECDH share               | 65 octets of SEC1-encoded shared point                   | 97 octets of SEC1-encoded shared point                   |
-| Key share                | 32 octets                                                | 64 octets                                                |
-| Hash                     | SHA3-256                                                 | SHA3-512                                                 |
+| ECDH key share           | 32 octets                                                | 48 octets                                                |
 
 The SEC1 format for point encoding is defined in {{sec1-format}}.
 
-The various procedures to perform the operations of an ECC-based KEM are defined in the following subsections.
+The various procedures to perform the operations of an ECDH KEM are defined in the following subsections.
 Specifically, each of these subsections defines the instances of the following operations:
 
     (ecdhCipherText, ecdhKeyShare) <- ECDH-KEM.Encaps(ecdhPublicKey)
 
 and
 
-    (ecdhKeyShare) <- ECDH-KEM.Decaps(ecdhSecretKey, ecdhCipherText, ecdhPublicKey)
+    (ecdhKeyShare) <- ECDH-KEM.Decaps(ecdhCipherText, ecdhSecretKey)
 
 To instantiate `ECDH-KEM`, one must select a parameter set from {{tab-ecdh-nist-artifacts}} or {{tab-ecdh-brainpool-artifacts}}.
 
@@ -540,15 +324,16 @@ To instantiate `ECDH-KEM`, one must select a parameter set from {{tab-ecdh-nist-
 #### ECDH-KEM {#ecdh-kem}
 
 The operation `ECDH-KEM.Encaps()` is defined as follows:
+
 1. Generate an ephemeral key pair {`v`, `V=vG`} as defined in {{SP800-186}} or {{RFC5639}} where `v` is a random scalar with `0 < v < n`, `n` being the base point order of the elliptic curve domain parameters
 
- 2. Compute the shared point `S = vR`, where `R` is the component public key `ecdhPublicKey`, according to {{SP800-186}} or {{RFC5639}}
+ 2. Compute the shared point `S = vR`, where `R` is the recipient's public key `ecdhPublicKey`, according to {{SP800-186}} or {{RFC5639}}
 
  3. Extract the `X` coordinate from the SEC1 encoded point `S = 04 || X || Y` as defined in section {{sec1-format}}
 
  4. Set the output `ecdhCipherText` to the SEC1 encoding of `V`
 
- 5. Set the output `ecdhKeyShare` to `Hash(X || ecdhCipherText || ecdhPublicKey)`, with `Hash` chosen according to {{tab-ecdh-nist-artifacts}} or {{tab-ecdh-brainpool-artifacts}}
+ 5. Set the output `ecdhKeyShare` to `X`
 
 The operation `ECDH-KEM.Decaps()` is defined as follows:
 
@@ -556,7 +341,7 @@ The operation `ECDH-KEM.Decaps()` is defined as follows:
 
  2. Extract the `X` coordinate from the SEC1 encoded point `S = 04 || X || Y` as defined in section {{sec1-format}}
 
- 3. Set the output `ecdhKeyShare` to `Hash(X || ecdhCipherText || ecdhPublicKey)`, with `Hash` chosen according to {{tab-ecdh-nist-artifacts}} or {{tab-ecdh-brainpool-artifacts}}
+ 3. Set the output `ecdhKeyShare` to `X`
 
 ### ML-KEM {#mlkem-ops}
 
@@ -583,7 +368,7 @@ All artifacts are encoded as defined in [FIPS-203].
 | Ciphertext             | 768 octets | 1088 octets | 1568 octets |
 | Key share              | 32 octets  | 32 octets   | 32 octets   |
 
-To instantiate `ML-KEM`, one must select a parameter set from {{tab-mlkem-artifacts}}.
+To instantiate `ML-KEM`, one must select a parameter set from the column "ML-KEM" of {{tab-mlkem-artifacts}}.
 
 ## Composite Encryption Schemes with ML-KEM {#ecc-mlkem}
 
@@ -602,25 +387,25 @@ The ML-KEM + ECDH composite public-key encryption schemes are built according to
 
  - The ML-KEM encapsulation algorithm is invoked to create an ML-KEM ciphertext together with an ML-KEM symmetric key share.
 
- - The encapsulation algorithm of an ECDH-KEM is invoked to create an ECC ciphertext together with an ECC symmetric key share.
+ - The encapsulation algorithm of an ECDH KEM is invoked to create an ECDH ciphertext together with an ECDH symmetric key share.
 
- - A Key-Encryption-Key (KEK) is computed as the output of a key combiner that receives as input both of the above created symmetric key shares and protocol binding information.
+ - A Key-Encryption-Key (KEK) is computed as the output of a key combiner that receives as input both of the above created symmetric key shares, the ECDH ciphertext, the ECDH public key, and the protocol binding information.
 
  - The session key for content encryption is then wrapped as described in {{RFC3394}} using AES-256 as algorithm and the KEK as key.
 
- - The PKESK package's algorithm-specific parts are made up of the ML-KEM ciphertext, the ECC ciphertext, and the wrapped session key.
+ - The PKESK packet's algorithm-specific parts are made up of the ML-KEM ciphertext, the ECDH ciphertext, and the wrapped session key.
 
-### Key combiner {#kem-key-combiner}
+### Key Combiner {#kem-key-combiner}
 
-For the composite KEM schemes defined in this document the procedure `multiKeyCombine` that is defined in [draft-ietf-openpgp-pqc-12] Section 4.2.1 MUST be used to compute the KEK that wraps a session key.
+For the composite KEM schemes defined in this document the procedure `multiKeyCombine` that is defined in {{Section 4.2.1 of I-D.draft-ietf-openpgp-pqc}} MUST be used to compute the KEK that wraps a session key.
 
-### Key generation procedure {#ecc-mlkem-generation}
+### Key Generation Procedure {#ecc-mlkem-generation}
 
-The implementation MUST independently generate the ML-KEM and the ECC component keys.
-ML-KEM key generation follows the specification [FIPS-203] and the artifacts are encoded as fixed-length octet strings as defined in {{mlkem-ops}}.
-For ECC this is done following the relative specification in {{SP800-186}} or {{RFC5639}}, and encoding the outputs as fixed-length octet strings in the format specified in {{tab-ecdh-nist-artifacts}} or {{tab-ecdh-brainpool-artifacts}}.
+The implementation MUST generate the ML-KEM and the ECDH component keys independently.
+ML-KEM key generation follows the specification in [FIPS-203], and the artifacts are encoded as fixed-length octet strings whose sizes are listed {{mlkem-ops}}.
+ECDH key generation follows the specification in {{SP800-186}} or {{RFC5639}}, and the artifacts are encoded as fixed-length octet strings whose sizes and format are listed in {{tab-ecdh-nist-artifacts}} or {{tab-ecdh-brainpool-artifacts}}.
 
-### Encryption procedure {#ecc-mlkem-encryption}
+### Encryption Procedure {#ecc-mlkem-encryption}
 
 The procedure to perform public-key encryption with an ML-KEM + ECDH composite scheme is as follows:
 
@@ -636,13 +421,13 @@ The procedure to perform public-key encryption with an ML-KEM + ECDH composite s
 
  6. Compute `(mlkemCipherText, mlkemKeyShare) = ML-KEM.Encaps(mlkemPublicKey)`
 
- 7. Compute `KEK = multiKeyCombine(mlkemKeyShare, ecdhKeyShare, ecdhCipherText, ecdhPublicKey, algId)`
+ 7. Compute `KEK = multiKeyCombine(mlkemKeyShare, ecdhKeyShare, ecdhCipherText, ecdhPublicKey, algId)` as defined in {{kem-key-combiner}}
 
  8. Compute `C = AESKeyWrap(KEK, sessionKey)` with AES-256 as per {{RFC3394}} that includes a 64 bit integrity check
 
  9. Output the algorithm specific part of the PKESK as `ecdhCipherText || mlkemCipherText || len(C, symAlgId) (|| symAlgId) || C`, where both `symAlgId` and `len(C, symAlgId)` are single octet fields, `symAlgId` denotes the symmetric algorithm ID used and is present only for a v3 PKESK, and `len(C, symAlgId)` denotes the combined octet length of the fields specified as the arguments.
 
-### Decryption procedure
+### Decryption Procedure
 
 The procedure to perform public-key decryption with an ML-KEM + ECDH composite scheme is as follows:
 
@@ -658,17 +443,17 @@ The procedure to perform public-key decryption with an ML-KEM + ECDH composite s
 
  6. Parse `ecdhCipherText`, `mlkemCipherText`, and `C` from `encryptedKey` encoded as `ecdhCipherText || mlkemCipherText || len(C, symAlgId) (|| symAlgId) || C` as specified in {{ecc-mlkem-pkesk}}, where `symAlgId` is present only in the case of a v3 PKESK.
 
- 7. Compute `(ecdhKeyShare) = ECDH-KEM.Decaps(ecdhCipherText, ecdhSecretKey, ecdhPublicKey)`
+ 7. Compute `(ecdhKeyShare) = ECDH-KEM.Decaps(ecdhCipherText, ecdhSecretKey)`
 
  8. Compute `(mlkemKeyShare) = ML-KEM.Decaps(mlkemCipherText, mlkemSecretKey)`
 
- 9. Compute `KEK = multiKeyCombine(mlkemKeyShare, ecdhKeyShare, ecdhCipherText, ecdhPublicKey, algId)`
+ 9. Compute `KEK = multiKeyCombine(mlkemKeyShare, ecdhKeyShare, ecdhCipherText, ecdhPublicKey, algId)` as defined in {{kem-key-combiner}}
 
  10. Compute `sessionKey = AESKeyUnwrap(KEK, C)` with AES-256 as per {{RFC3394}}, aborting if the 64 bit integrity check fails
 
  11. Output `sessionKey`
 
-## Packet specifications
+## Packet Specifications
 
 ### Public-Key Encrypted Session Key Packets (Packet Type ID 1) {#ecc-mlkem-pkesk}
 
@@ -692,7 +477,6 @@ In the case of a v3 PKESK, a receiving implementation MUST check if the length o
 
 Implementations MUST NOT use the obsolete Symmetrically Encrypted Data packet (Packet Type ID 9) to encrypt data protected with the algorithms described in this document.
 
-
 ### Key Material Packets {#mlkem-ecc-key}
 
 The composite ML-KEM + ECDH schemes defined in this specification MUST be used only with v6 keys, as defined in [RFC9580], or newer versions defined by updates of that document.
@@ -701,7 +485,7 @@ The composite ML-KEM + ECDH schemes defined in this specification MUST be used o
 
 The algorithm-specific public key is this series of values:
 
- - A fixed-length octet string representing an EC point public key, in the point format associated with the curve specified in {{ecc-kem}}.
+ - A fixed-length octet string representing an ECC public key, in the point format associated with the curve specified in {{ecc-kem}}.
 
  - A fixed-length octet string containing the ML-KEM public key, whose length depends on the algorithm ID as specified in {{tab-mlkem-artifacts}}.
 
@@ -709,7 +493,7 @@ The algorithm-specific public key is this series of values:
 
 The algorithm-specific secret key is these two values:
 
- - A fixed-length octet string of the encoded secret scalar, whose encoding and length depend on the algorithm ID as specified in {{ecc-kem}}.
+ - A fixed-length octet string of the encoded ECDH secret key, whose encoding and length depend on the algorithm ID as specified in {{ecc-kem}}.
 
  - A fixed-length octet string containing the ML-KEM secret key in seed format, whose length is 64 octets (compare {{tab-mlkem-artifacts}}).
    The seed format is defined in accordance with Section 3.3 of [FIPS-203].
@@ -718,9 +502,9 @@ The algorithm-specific secret key is these two values:
 
 # Composite Signature Schemes
 
-## Building blocks
+## Building Blocks
 
-### ECDSA-Based signatures {#ecdsa-signature}
+### ECDSA-Based Signatures {#ecdsa-signature}
 
 To sign and verify with ECDSA the following operations are defined:
 
@@ -729,8 +513,8 @@ To sign and verify with ECDSA the following operations are defined:
 
 and
 
-    (verified) <- ECDSA.Verify(ecdsaPublicKey, ecdsaSignatureR,
-                               ecdsaSignatureS, dataDigest)
+    (verified) <- ECDSA.Verify(ecdsaPublicKey, dataDigest,
+                               ecdsaSignatureR, ecdsaSignatureS)
 
 Here, the operation `ECDSA.Sign()` is defined as the algorithm in Section "6.4.1 ECDSA Signature Generation Algorithm" of {{SP800-186-5}}, however, excluding Step 1: `H = Hash(M)` in that algorithm specification, as in this specification the message digest `H` is a direct input to the operation `ECDSA.Sign()`. Equivalently, the operation `ECDSA.Sign()` can be understood as representing the algorithm under Section "4.2.1.1. Signature Algorithm" in {{TR-03111}}, again with the difference that in this specification the message digest `H_Tau(M)` appearing in Step 5 of the algorithm specification is the direct input to the operation `ECDSA.Sign()` and thus the hash computation is not carried out.
 The same statement holds for the definition of the verification operation `ECDSA.Verify()`: it is given either through the algorithm defined in Section "6.4.2 ECDSA Signature Verification Algorithm" of {{SP800-186-5}} omitting the message digest computation in Step 2 or by the algorithm in Section "4.2.1.2. Verification Algorithm" of {{TR-03111}} omitting the message digest computation in Step 3.
@@ -744,13 +528,12 @@ The following table describes the ECDSA parameters and artifact lengths:
 |                      | NIST-P-256                       | NIST P-384                                                 | brainpoolP256r1                       | brainpoolP384r1                       |
 ---------------------: | -------------------------------- | ---------------------------------------------------------- | ------------------------------------- | ------------------------------------- |
 Algorithm ID reference | TBD (ML-DSA-44+ECDSA-NIST-P-256) | TBD (ML-DSA-65+ECDSA-NIST-P-384,ML-DSA-87+ECDSA-NIST-P-384 | TBD (ML-DSA-65+ECDSA-brainpoolP256r1) | TBD (ML-DSA-87+ECDSA-brainpoolP384r1) |
-Field size             | 32 octets                        | 48 octets                                                  | 32 octets                             | 48 octets                             |
 Public key             | 65 octets                        | 97 octets                                                  | 65 octets                             | 97 octets                             |
 Secret key             | 32 octets                        | 48 octets                                                  | 32 octets                             | 48 octets                             |
 Signature value R      | 32 octets                        | 48 octets                                                  | 32 octets                             | 48 octets                             |
 Signature value S      | 32 octets                        | 48 octets                                                  | 32 octets                             | 48 octets                             |
 
-### ML-DSA signatures {#mldsa-signature}
+### ML-DSA Signatures {#mldsa-signature}
 
 Throughout this specification ML-DSA refers to the default pure and hedged version of ML-DSA defined in [FIPS-204].
 
@@ -777,27 +560,25 @@ All artifacts are encoded as defined in [FIPS-204].
 
 ## Composite Signature Schemes with ML-DSA {#ecc-mldsa}
 
-### Key generation procedure {#ecc-mldsa-generation}
+### Key Generation Procedure {#ecc-mldsa-generation}
 
-The implementation MUST independently generate the ML-DSA and the ECC component keys.
-ML-DSA key generation follows the specification [FIPS-204] and the artifacts are encoded as fixed-length octet strings as defined in {{mldsa-signature}}.
-For ECC this is done following the relative specification in {{SP800-186}} or {{RFC5639}}, and encoding the artifacts as specified in {{ecdsa-signature}} as fixed-length octet strings.
+The implementation MUST generate the ML-DSA and the ECDSA component keys independently.
+ML-DSA key generation follows the specification in [FIPS-204] and the artifacts are encoded as fixed-length octet strings whose sizes are listed in {{mldsa-signature}}.
+ECDSA key generation follows the specification in {{SP800-186}} or {{RFC5639}}, and the artifacts are encoded as fixed-length octet strings whose sizes are listed in {{ecdsa-signature}}.
 
 ### Signature Generation
 
-
 To sign a message `M` with ML-DSA + ECDSA the following sequence of operations has to be performed:
 
- 1. Generate `dataDigest` according to {{?RFC9580}}, Section 5.2.4
+ 1. Generate `dataDigest` according to {{Section 5.2.4 of RFC9580}}
 
  2. Create the ECDSA signature over `dataDigest` with `ECDSA.Sign()` from {{ecdsa-signature}}
 
  3. Create the ML-DSA signature over `dataDigest` with `ML-DSA.Sign()` from {{mldsa-signature}}
 
- 4. Encode the ECDSA and ML-DSA signatures according to the packet structure given in {{ecc-mldsa-sig-packet}}.
+ 4. Encode the ECDSA and ML-DSA signatures according to the packet structure given in {{ecc-mldsa-sig-packet}}
 
 ### Signature Verification
-
 
 To verify an ML-DSA + ECDSA signature the following sequence of operations has to be performed:
 
@@ -805,7 +586,7 @@ To verify an ML-DSA + ECDSA signature the following sequence of operations has t
 
  2. Verify the ML-DSA signature with `ML-DSA.Verify()` from {{mldsa-signature}}
 
-As specified in {{composite-signatures}} an implementation MUST validate both signatures, i.e. ECDSA and ML-DSA, successfully to state that a composite ML-DSA + ECDSA signature is valid.
+As specified in {{composite-signatures}} an implementation MUST validate both signatures, that is, ECDSA and ML-DSA, successfully to state that a composite ML-DSA + ECDSA signature is valid.
 
 ## Packet Specifications
 
@@ -832,7 +613,7 @@ The composite ML-DSA + ECDSA schemes MUST be used only with v6 keys, as defined 
 
 The algorithm-specific public key for ML-DSA + ECDSA keys is this series of values:
 
- - A fixed-length octet string representing the ECDSA public key in SEC1 format, as specified in section {{sec1-format}} and with length specified in {{tab-ecdsa-artifacts}}.
+ - A fixed-length octet string representing the ECDSA public key in SEC1 format, as specified in section {{sec1-format}}, whose length depends on the algorithm ID as specified in {{tab-ecdsa-artifacts}}.
 
  - A fixed-length octet string containing the ML-DSA public key, whose length depends on the algorithm ID as specified in {{tab-mldsa-artifacts}}.
 
@@ -840,28 +621,24 @@ The algorithm-specific public key for ML-DSA + ECDSA keys is this series of valu
 
 The algorithm-specific secret key for ML-DSA + ECDSA keys is this series of values:
 
- - A fixed-length octet string representing the ECDSA secret key as a big-endian encoded integer, whose length depends on the algorithm used as specified in {{tab-ecdsa-artifacts}}.
+ - A fixed-length octet string representing the ECDSA secret key as a big-endian encoded integer, whose length depends on the algorithm ID as specified in {{tab-ecdsa-artifacts}}.
 
  - A fixed-length octet string containing the ML-DSA secret key in seed format, whose length is 32 octets (compare {{tab-mldsa-artifacts}}).
    The seed format is defined in accordance with Section 3.6.3 of [FIPS-204].
    Namely, the secret key is given by the value `xi` generated in step 1 of `ML-DSA.KeyGen` [FIPS-204].
    Upon parsing the secret key format, or before using the secret key, for the expansion of the key, the function `ML-DSA.KeyGen_internal` [FIPS-204] has to be invoked with the parsed value of `xi` as input.
 
-
-
-
-
 # Security Considerations
 
-The following security considerations given in {{draft-ietf-openpgp-pqc-12}} equally apply to this document:
+The following security considerations given in {{I-D.draft-ietf-openpgp-pqc}} equally apply to this document:
 
-- the security aspects of composite signatures (Section 9.1 in {{draft-ietf-openpgp-pqc-12}}),
-- the arguments for the security features of the KEM combiner given in Section 9.2 of {{draft-ietf-openpgp-pqc-12}}, as also the NIST and Brainpool curves represent nominal groups according to {{ABH+21}},
-- the considerations regarding domain separartion and context binding for the KEM combiner (Section 9.2.1 in {{draft-ietf-openpgp-pqc-12}}),
-- the use of the hedged variant of ML-DSA (Section 9.3 in {{draft-ietf-openpgp-pqc-12}}),
-- the minimum digest size for PQ/T signatures (Section 9.4 in {{draft-ietf-openpgp-pqc-12}}),
-- the use of symmetric encryption in SEIPD packets (Section 9.5 in {{draft-ietf-openpgp-pqc-12}}),
-- and key generation for composite schemes (Section 9.6 in {{draft-ietf-openpgp-pqc-12}}).
+- the security aspects of composite signatures (Section 9.1 in {{I-D.draft-ietf-openpgp-pqc}}),
+- the arguments for the security features of the KEM combiner given in Section 9.2 of {{I-D.draft-ietf-openpgp-pqc}}, as also the NIST and Brainpool curves represent nominal groups according to {{ABH+21}},
+- the considerations regarding domain separation and context binding for the KEM combiner (Section 9.2.1 in {{I-D.draft-ietf-openpgp-pqc}}),
+- the use of the hedged variant of ML-DSA (Section 9.3 in {{I-D.draft-ietf-openpgp-pqc}}),
+- the minimum digest size for PQ/T signatures (Section 9.4 in {{I-D.draft-ietf-openpgp-pqc}}),
+- the use of symmetric encryption in SEIPD packets (Section 9.5 in {{I-D.draft-ietf-openpgp-pqc}}),
+- and key generation for composite schemes (Section 9.6 in {{I-D.draft-ietf-openpgp-pqc}}).
 
 When implementing or using any of the algorithms defined in this specification, the above referenced security considerations should be noted.
 
@@ -898,15 +675,14 @@ This section gives the history of changes in the respective document versions. T
 
 - Completed the IANA table.
 - Added "Security Considerations" section.
-- Alignment of various technical details to draft-ietf-openpgp-pqc-12.
-- Various editorial alignments to draft-ietf-openpgp-pqc-12.
+- Alignment of various technical details to {{I-D.draft-ietf-openpgp-pqc}}.
+- Various editorial alignments to {{I-D.draft-ietf-openpgp-pqc}}.
 
 ## draft-ehlen-openpgp-nist-bp-comp-01
 
-- Replaced the explicit description of the KEM combiner with a reference to draft-ietf-openpgp-pqc.
+- Replaced the explicit description of the KEM combiner with a reference to {{I-D.draft-ietf-openpgp-pqc}}.
 
 # Contributors
-Stavros Kousidis
 
 --- back
 

--- a/draft-ehlen-openpgp-nist-bp-comp.md
+++ b/draft-ehlen-openpgp-nist-bp-comp.md
@@ -291,6 +291,7 @@ In this section we define the encryption, decryption, and data formats for the E
 |                          | NIST P-256                                               | NIST P-384                                                        |
 | ------------------------ | -------------------------------------------------------- | --------------------------------------------------------          |
 | Algorithm ID reference   | TBD (ML-KEM-512+ECDH-NIST-P-256)                         | TBD (ML-KEM-768+ECDH-NIST-P-384, ML-KEM-1024+ECDH-NIST-P-384, )   |
+| Field size               | 32 octets                                                | 48 octets                                                         |
 | ECDH KEM                 | ECDH-KEM {{ecdh-kem}}                                    | ECDH-KEM {{ecdh-kem}}                                             |
 | ECDH public key          | 65 octets of SEC1-encoded public point                   | 97 octets of SEC1-encoded public point                            |
 | ECDH secret key          | 32 octets big-endian encoded secret scalar               | 48 octets big-endian encoded secret scalar                        |
@@ -301,6 +302,7 @@ In this section we define the encryption, decryption, and data formats for the E
 |                          | brainpoolP256r1                                          | brainpoolP384r1                                          |
 | ------------------------ | -------------------------------------------------------- | -------------------------------------------------------- |
 | Algorithm ID reference   | TBD (ML-KEM-768+ECDH-brainpoolP256r1)                    | TBD (ML-KEM-1024+ECDH-brainpoolP384r1)                   |
+| Field size               | 32 octets                                                | 48 octets                                                |
 | ECDH KEM                 | ECDH-KEM {{ecdh-kem}}                                    | ECDH-KEM {{ecdh-kem}}                                    |
 | ECDH public key          | 65 octets of SEC1-encoded public point                   | 97 octets of SEC1-encoded public point                   |
 | ECDH secret key          | 32 octets big-endian encoded secret scalar               | 48 octets big-endian encoded secret scalar               |

--- a/draft-ehlen-openpgp-nist-bp-comp.md
+++ b/draft-ehlen-openpgp-nist-bp-comp.md
@@ -265,7 +265,7 @@ This draft will not be sent to IANA without every listed algorithm having a non-
 
 ## Composite KEMs
 
-The ML-KEM + ECDH public-key encryption involves both the ML-KEM and an ECDH KEM in an a priori non-separable manner.
+The ML-KEM + ECDH public-key encryption involves both the ML-KEM and an ECDH KEM in a non-separable manner.
 This is achieved via KEM combination, i.e. both key encapsulations/decapsulations are performed in parallel, and the resulting key shares are fed into a key combiner to produce a single shared secret for message encryption.
 
 ## Composite Signatures

--- a/draft-ehlen-openpgp-nist-bp-comp.md
+++ b/draft-ehlen-openpgp-nist-bp-comp.md
@@ -407,51 +407,25 @@ ECDH key generation follows the specification in {{SP800-186}} or {{RFC5639}}, a
 
 ### Encryption Procedure {#ecc-mlkem-encryption}
 
-The procedure to perform public-key encryption with an ML-KEM + ECDH composite scheme is as follows:
+The procedure to perform public-key encryption with an ML-KEM + ECDH composite
+scheme is identical to the one described in {{Section 4.2.3 of
+I-D.draft-ietf-openpgp-pqc}}, except that references are replaced as follows:
 
- 1. Take the recipient's authenticated public-key packet `pkComposite` and `sessionKey` as input
+ - (Step 3) See {{mlkem-ecc-key}} in the present document.
 
- 2. Parse the algorithm ID from `pkComposite` and set it as `algId`
-
- 3. Extract the `ecdhPublicKey` and `mlkemPublicKey` component from the algorithm specific data encoded in `pkComposite` with the format specified in {{mlkem-ecc-key}}.
-
- 4. Instantiate the ECDH-KEM and the ML-KEM depending on the algorithm ID according to {{tab-mlkem-ecc-composite}}
-
- 5. Compute `(ecdhCipherText, ecdhKeyShare) = ECDH-KEM.Encaps(ecdhPublicKey)`
-
- 6. Compute `(mlkemCipherText, mlkemKeyShare) = ML-KEM.Encaps(mlkemPublicKey)`
-
- 7. Compute `KEK = multiKeyCombine(mlkemKeyShare, ecdhKeyShare, ecdhCipherText, ecdhPublicKey, algId)` as defined in {{kem-key-combiner}}
-
- 8. Compute `C = AESKeyWrap(KEK, sessionKey)` with AES-256 as per {{RFC3394}} that includes a 64 bit integrity check
-
- 9. Output the algorithm specific part of the PKESK as `ecdhCipherText || mlkemCipherText || len(C, symAlgId) (|| symAlgId) || C`, where both `symAlgId` and `len(C, symAlgId)` are single octet fields, `symAlgId` denotes the symmetric algorithm ID used and is present only for a v3 PKESK, and `len(C, symAlgId)` denotes the combined octet length of the fields specified as the arguments.
+ - (Step 4) See {{tab-mlkem-ecc-composite}} in the present document.
 
 ### Decryption Procedure
 
-The procedure to perform public-key decryption with an ML-KEM + ECDH composite scheme is as follows:
+The procedure to perform public-key decryption with an ML-KEM + ECDH composite
+scheme is identical to the one described in {{Section 4.2.4 of
+I-D.draft-ietf-openpgp-pqc}}, except that references are replaced as follows:
 
- 1. Take the matching PKESK and own secret key packet as input
+ - (Step 4) See {{mlkem-ecc-key}} in the present document.
 
- 2. From the PKESK extract the algorithm ID as `algId` and the wrapped session key as `encryptedKey`
+ - (Step 5) See {{tab-mlkem-ecc-composite}} in the present document.
 
- 3. Check that the own and the extracted algorithm ID match
-
- 4. Parse the `ecdhSecretKey` and `mlkemSecretKey` from the algorithm specific data of the own secret key encoded in the format specified in {{mlkem-ecc-key}}
-
- 5. Instantiate the ECDH-KEM and the ML-KEM depending on the algorithm ID according to {{tab-mlkem-ecc-composite}}
-
- 6. Parse `ecdhCipherText`, `mlkemCipherText`, and `C` from `encryptedKey` encoded as `ecdhCipherText || mlkemCipherText || len(C, symAlgId) (|| symAlgId) || C` as specified in {{ecc-mlkem-pkesk}}, where `symAlgId` is present only in the case of a v3 PKESK.
-
- 7. Compute `(ecdhKeyShare) = ECDH-KEM.Decaps(ecdhCipherText, ecdhSecretKey)`
-
- 8. Compute `(mlkemKeyShare) = ML-KEM.Decaps(mlkemCipherText, mlkemSecretKey)`
-
- 9. Compute `KEK = multiKeyCombine(mlkemKeyShare, ecdhKeyShare, ecdhCipherText, ecdhPublicKey, algId)` as defined in {{kem-key-combiner}}
-
- 10. Compute `sessionKey = AESKeyUnwrap(KEK, C)` with AES-256 as per {{RFC3394}}, aborting if the 64 bit integrity check fails
-
- 11. Output `sessionKey`
+ - (Step 6) See {{ecc-mlkem-pkesk}} in the present document.
 
 ## Packet Specifications
 


### PR DESCRIPTION
I felt the editorial changes needed to align definitions and text to draft-ietf-openpgp-pqc to be quiet substantial and I think that it is not the last sweep that the document needs.

- I moved references that are needed to implement that specification (like curve definitions) to the normative section as we did it for FIPS 203, 204 etc. in draft-ietf-openpgp-pqc
- Tried to align text as much as possible
- Tried to align the artefact tables
- Capitalize the section headings as we did in the other I-D
- etc.

I felt the need to de-duplicate redundant text, so I made a proposal for the Encryption/Decryption Procedure of ML-KEM+ECDH. I would expect that this needs to be done for all other procedures as well.